### PR TITLE
Replace LIMIT_AS_RANGE macro with constexpr function

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Ranges/issues/76
+Your prepared branch: issue-76-88af9c31
+Your prepared working directory: /tmp/gh-issue-solver-1757591268935
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Ranges/issues/76
-Your prepared branch: issue-76-88af9c31
-Your prepared working directory: /tmp/gh-issue-solver-1757591268935
-
-Proceed.

--- a/cpp/Platform.Ranges/Range.h
+++ b/cpp/Platform.Ranges/Range.h
@@ -1,26 +1,31 @@
 ﻿namespace Platform::Ranges
 {
-    #define LIMIT_AS_RANGE(type) std::numeric_limits<type>::lowest(), std::numeric_limits<type>::max()
+    namespace Internal
+    {
+        template<typename T>
+        constexpr Range<T> FullRange() noexcept
+        {
+            return Range<T>(std::numeric_limits<T>::lowest(), std::numeric_limits<T>::max());
+        }
+    }
 
-    constexpr auto SByte  = Range(LIMIT_AS_RANGE(std::int8_t));
+    constexpr auto SByte  = Internal::FullRange<std::int8_t>();
 
-    constexpr auto Int16  = Range(LIMIT_AS_RANGE(std::int16_t));
+    constexpr auto Int16  = Internal::FullRange<std::int16_t>();
 
-    constexpr auto Int32  = Range(LIMIT_AS_RANGE(std::int32_t));
+    constexpr auto Int32  = Internal::FullRange<std::int32_t>();
 
-    constexpr auto Int64  = Range(LIMIT_AS_RANGE(std::int64_t));
+    constexpr auto Int64  = Internal::FullRange<std::int64_t>();
 
-    constexpr auto Byte   = Range(LIMIT_AS_RANGE(std::uint8_t));
+    constexpr auto Byte   = Internal::FullRange<std::uint8_t>();
 
-    constexpr auto UInt16 = Range(LIMIT_AS_RANGE(std::uint16_t));
+    constexpr auto UInt16 = Internal::FullRange<std::uint16_t>();
 
-    constexpr auto UInt32 = Range(LIMIT_AS_RANGE(std::uint32_t));
+    constexpr auto UInt32 = Internal::FullRange<std::uint32_t>();
 
-    constexpr auto UInt64 = Range(LIMIT_AS_RANGE(std::uint64_t));
+    constexpr auto UInt64 = Internal::FullRange<std::uint64_t>();
 
-    constexpr auto Single = Range(LIMIT_AS_RANGE(std::float_t));
+    constexpr auto Single = Internal::FullRange<std::float_t>();
 
-    constexpr auto Double = Range(LIMIT_AS_RANGE(std::double_t));
-
-    #undef LIMIT_AS_RANGE
+    constexpr auto Double = Internal::FullRange<std::double_t>();
 }


### PR DESCRIPTION
## 📝 Summary

This PR replaces the `LIMIT_AS_RANGE` macro with a modern constexpr template function, addressing issue #76.

## 🔄 Changes Made

- **Removed**: `LIMIT_AS_RANGE` macro and its `#undef` directive
- **Added**: `Internal::FullRange<T>()` constexpr template function in the `Internal` namespace
- **Updated**: All predefined range constants (`SByte`, `Int16`, `Int32`, etc.) to use the new function

## ✨ Benefits

- **Type Safety**: Template function provides compile-time type checking vs. macro expansion
- **Debugging**: Function calls are easier to debug and step through than macro expansions  
- **Namespace Safety**: Function is contained within `Internal` namespace, avoiding global pollution
- **Modern C++**: Follows modern C++20 best practices by using constexpr functions over macros
- **Maintainability**: Template function is more readable and maintainable than macro

## 🏗️ Implementation Details

The original macro:
```cpp
#define LIMIT_AS_RANGE(type) std::numeric_limits<type>::lowest(), std::numeric_limits<type>::max()
```

Has been replaced with:
```cpp
namespace Internal
{
    template<typename T>
    constexpr Range<T> FullRange() noexcept
    {
        return Range<T>(std::numeric_limits<T>::lowest(), std::numeric_limits<T>::max());
    }
}
```

Usage changed from:
```cpp
constexpr auto SByte = Range(LIMIT_AS_RANGE(std::int8_t));
```

To:
```cpp
constexpr auto SByte = Internal::FullRange<std::int8_t>();
```

## ✅ Testing

- ✅ Code compiles successfully with C++20 standard
- ✅ All predefined ranges (`SByte`, `Int32`, `UInt64`, etc.) produce correct min/max values
- ✅ Template function works correctly for all numeric types (signed/unsigned integers, floats)

## 📋 Fixes

Closes #76

---

🤖 Generated with [Claude Code](https://claude.ai/code)