### PR TITLE
Fix Range template deduction guide to support single parameter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Ranges/issues/66
-Your prepared branch: issue-66-a32b9223
-Your prepared working directory: /tmp/gh-issue-solver-1757736731223
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Ranges/issues/66
+Your prepared branch: issue-66-a32b9223
+Your prepared working directory: /tmp/gh-issue-solver-1757736731223
+
+Proceed.

--- a/cpp/Platform.Ranges/Range[T].h
+++ b/cpp/Platform.Ranges/Range[T].h
@@ -72,8 +72,8 @@
         public: template<typename TOther> requires std::convertible_to<T, TOther> constexpr explicit(not Internal::implicit_convertible_to<T, TOther>) operator Range<TOther>() const noexcept(noexcept(static_cast<TOther>(Minimum))) { return {static_cast<TOther>(Minimum), static_cast<TOther>(Maximum)}; }
     };
 
-    template<typename T, typename... U>
-    Range(T, U...) -> Range<std::common_type_t<T, U...>>;
+    template<typename... T>
+    Range(T...) -> Range<std::common_type_t<T...>>;
 }
 
 namespace std

--- a/examples/test_deduction_guide.cpp
+++ b/examples/test_deduction_guide.cpp
@@ -1,0 +1,22 @@
+#include "../cpp/Platform.Ranges/Platform.Ranges.h"
+#include <iostream>
+#include <type_traits>
+
+int main()
+{
+    // Test single parameter deduction
+    auto range1 = Platform::Ranges::Range(5);
+    static_assert(std::is_same_v<decltype(range1), Platform::Ranges::Range<int>>);
+    
+    // Test two parameter deduction  
+    auto range2 = Platform::Ranges::Range(1, 10);
+    static_assert(std::is_same_v<decltype(range2), Platform::Ranges::Range<int>>);
+    
+    // Test mixed types deduction
+    auto range3 = Platform::Ranges::Range(1, 10.5);
+    static_assert(std::is_same_v<decltype(range3), Platform::Ranges::Range<double>>);
+    
+    std::cout << "All deduction guide tests passed!" << std::endl;
+    
+    return 0;
+}


### PR DESCRIPTION
## Summary
Fixes the Range class template deduction guide to support single parameter construction.

The previous deduction guide:
```cpp
template<typename T, typename... U>
Range(T, U...) -> Range<std::common_type_t<T, U...>>;
```

Required at least two parameters (T and U...), but Range has a single-parameter constructor for creating ranges with the same minimum and maximum value.

This change fixes the deduction guide to use variadic template parameters:
```cpp
template<typename... T>
Range(T...) -> Range<std::common_type_t<T...>>;
```

This allows both single and multiple parameter deduction to work correctly:
- `Range(5)` → `Range<int>`
- `Range(1, 10)` → `Range<int>`  
- `Range(1, 10.5)` → `Range<double>`

## Test plan
- [x] Existing tests in RangeTests.cpp already cover both single parameter (`Range(5)`) and multiple parameter (`Range(1, 3)`) construction
- [x] Created additional test file to verify deduction guide behavior
- [x] No breaking changes - only extends functionality

Fixes #66

🤖 Generated with [Claude Code](https://claude.ai/code)