### PR TITLE
Add Positive static properties to Range class

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Ranges/issues/30
+Your prepared branch: issue-30-c6b6c2d5
+Your prepared working directory: /tmp/gh-issue-solver-1757814344355
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Ranges/issues/30
-Your prepared branch: issue-30-c6b6c2d5
-Your prepared working directory: /tmp/gh-issue-solver-1757814344355
-
-Proceed.

--- a/csharp/Platform.Ranges.Tests/RangeTests.cs
+++ b/csharp/Platform.Ranges.Tests/RangeTests.cs
@@ -53,5 +53,21 @@ namespace Platform.Ranges.Tests
             Assert.True(range1 != range2);
             Assert.NotEqual(range1, range2);
         }
+
+        [Fact]
+        public static void PositiveRangesTest()
+        {
+            Assert.Equal(1, Range.PositiveSByte.Minimum);
+            Assert.Equal(sbyte.MaxValue, Range.PositiveSByte.Maximum);
+            
+            Assert.Equal(1, Range.PositiveInt16.Minimum);
+            Assert.Equal(short.MaxValue, Range.PositiveInt16.Maximum);
+            
+            Assert.Equal(1, Range.PositiveInt32.Minimum);
+            Assert.Equal(int.MaxValue, Range.PositiveInt32.Maximum);
+            
+            Assert.Equal(1L, Range.PositiveInt64.Minimum);
+            Assert.Equal(long.MaxValue, Range.PositiveInt64.Maximum);
+        }
     }
 }

--- a/csharp/Platform.Ranges/Range.cs
+++ b/csharp/Platform.Ranges/Range.cs
@@ -71,5 +71,29 @@ namespace Platform.Ranges
         /// <para>Возвращает весь диапазон значений <see cref="decimal"/>.</para>
         /// </summary>
         public static readonly Range<decimal> Decimal = new Range<decimal>(decimal.MinValue, decimal.MaxValue);
+
+        /// <summary>
+        /// <para>Gets the positive <see cref="sbyte"/> values range (from 1 to <see cref="sbyte.MaxValue"/>).</para>
+        /// <para>Возвращает положительный диапазон значений <see cref="sbyte"/> (от 1 до <see cref="sbyte.MaxValue"/>).</para>
+        /// </summary>
+        public static readonly Range<sbyte> PositiveSByte = new Range<sbyte>(1, sbyte.MaxValue);
+
+        /// <summary>
+        /// <para>Gets the positive <see cref="short"/> values range (from 1 to <see cref="short.MaxValue"/>).</para>
+        /// <para>Возвращает положительный диапазон значений <see cref="short"/> (от 1 до <see cref="short.MaxValue"/>).</para>
+        /// </summary>
+        public static readonly Range<short> PositiveInt16 = new Range<short>(1, short.MaxValue);
+
+        /// <summary>
+        /// <para>Gets the positive <see cref="int"/> values range (from 1 to <see cref="int.MaxValue"/>).</para>
+        /// <para>Возвращает положительный диапазон значений <see cref="int"/> (от 1 до <see cref="int.MaxValue"/>).</para>
+        /// </summary>
+        public static readonly Range<int> PositiveInt32 = new Range<int>(1, int.MaxValue);
+
+        /// <summary>
+        /// <para>Gets the positive <see cref="long"/> values range (from 1 to <see cref="long.MaxValue"/>).</para>
+        /// <para>Возвращает положительный диапазон значений <see cref="long"/> (от 1 до <see cref="long.MaxValue"/>).</para>
+        /// </summary>
+        public static readonly Range<long> PositiveInt64 = new Range<long>(1L, long.MaxValue);
     }
 }


### PR DESCRIPTION
## Summary
- Implements issue #30 by adding static positive range properties to the Range class
- Added `Range.PositiveInt64` property to replace `(1L, long.MaxValue)` tuple pattern 
- Added consistent positive range properties for other integer types: `PositiveInt32`, `PositiveInt16`, `PositiveSByte`
- Added comprehensive unit tests verifying all new properties work correctly

## Changes
- **csharp/Platform.Ranges/Range.cs**: Added 4 new static readonly properties for positive ranges
- **csharp/Platform.Ranges.Tests/RangeTests.cs**: Added `PositiveRangesTest` method to verify functionality

## Test plan
- [x] All existing tests continue to pass
- [x] New test method `PositiveRangesTest` verifies correct minimum and maximum values for all positive range properties
- [x] Build completes successfully with no errors or warnings
- [x] Implementation follows existing code patterns and documentation style

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #30