### PR TITLE
Add missing comments to documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Ranges/issues/29
-Your prepared branch: issue-29-78b0dfb4
-Your prepared working directory: /tmp/gh-issue-solver-1757816652123
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Ranges/issues/29
+Your prepared branch: issue-29-78b0dfb4
+Your prepared working directory: /tmp/gh-issue-solver-1757816652123
+
+Proceed.

--- a/csharp/Platform.Ranges/EnsureExtensions.cs
+++ b/csharp/Platform.Ranges/EnsureExtensions.cs
@@ -225,7 +225,7 @@ namespace Platform.Ranges
         /// </summary>
         /// <typeparam name="TArgument"><para>Type of argument.</para><para>Тип аргумента.</para></typeparam>
         /// <param name="root"><para>The extension root to which this method is bound.</para><para>Корень-расширения, к которому привязан этот метод.</para></param>
-        /// <param name="argument"></param>
+        /// <param name="argument"><para>The argument's value.</para><para>Значение аргумента.</para></param>
         /// <param name="range"><para>The range restriction.</para><para>Ограничение в виде диапазона.</para></param>
         /// <param name="argumentName"><para>The argument's name.</para><para>Имя аргумента.</para></param>
         /// <param name="messageBuilder"><para>The thrown exception's message building <see cref="Func{String}"/>.</para><para>Собирающая сообщение для выбрасываемого исключения <see cref="Func{String}"/>.</para></param>
@@ -238,7 +238,7 @@ namespace Platform.Ranges
         /// </summary>
         /// <typeparam name="TArgument"><para>Type of argument.</para><para>Тип аргумента.</para></typeparam>
         /// <param name="root"><para>The extension root to which this method is bound.</para><para>Корень-расширения, к которому привязан этот метод.</para></param>
-        /// <param name="argument"></param>
+        /// <param name="argument"><para>The argument's value.</para><para>Значение аргумента.</para></param>
         /// <param name="range"><para>The range restriction.</para><para>Ограничение в виде диапазона.</para></param>
         /// <param name="argumentName"><para>The argument's name.</para><para>Имя аргумента.</para></param>
         /// <param name="message"><para>The message of the thrown exception.</para><para>Сообщение выбрасываемого исключения.</para></param>
@@ -251,7 +251,7 @@ namespace Platform.Ranges
         /// </summary>
         /// <typeparam name="TArgument"><para>Type of argument.</para><para>Тип аргумента.</para></typeparam>
         /// <param name="root"><para>The extension root to which this method is bound.</para><para>Корень-расширения, к которому привязан этот метод.</para></param>
-        /// <param name="argument"></param>
+        /// <param name="argument"><para>The argument's value.</para><para>Значение аргумента.</para></param>
         /// <param name="range"><para>The range restriction.</para><para>Ограничение в виде диапазона.</para></param>
         /// <param name="argumentName"><para>The argument's name.</para><para>Имя аргумента.</para></param>
         [Conditional("DEBUG")]
@@ -288,7 +288,7 @@ namespace Platform.Ranges
         /// </summary>
         /// <typeparam name="TArgument"><para>Type of argument.</para><para>Тип аргумента.</para></typeparam>
         /// <param name="root"><para>The extension root to which this method is bound.</para><para>Корень-расширения, к которому привязан этот метод.</para></param>
-        /// <param name="argument"></param>
+        /// <param name="argument"><para>The argument's value.</para><para>Значение аргумента.</para></param>
         /// <param name="range"><para>The range restriction.</para><para>Ограничение в виде диапазона.</para></param>
         [Conditional("DEBUG")]
         public static void ArgumentInRange<TArgument>(this EnsureOnDebugExtensionRoot root, TArgument argument, Range<TArgument> range) => Ensure.Always.ArgumentInRange(argument, range, null);

--- a/csharp/Platform.Ranges/Range[T].cs
+++ b/csharp/Platform.Ranges/Range[T].cs
@@ -9,6 +9,7 @@ namespace Platform.Ranges
     /// <para>Represents a range between minimum and maximum values.</para>
     /// <para>Представляет диапазон между минимальным и максимальным значениями.</para>
     /// </summary>
+    /// <typeparam name="T"><para>The type of the values that define the range bounds.</para><para>Тип значений, определяющих границы диапазона.</para></typeparam>
     /// <remarks>
     /// <para>Based on <a href="http://stackoverflow.com/questions/5343006/is-there-a-c-sharp-type-for-representing-an-integer-range">the question at StackOverflow</a>.</para>
     /// <para>Основано на <a href="http://stackoverflow.com/questions/5343006/is-there-a-c-sharp-type-for-representing-an-integer-range">вопросе в StackOverflow</a>.</para>
@@ -118,9 +119,10 @@ namespace Platform.Ranges
         public override bool Equals(object obj) => obj is Range<T> range ? Equals(range) : false;
 
         /// <summary>
-        /// Calculates the hash code for the current <see cref="Range{T}"/> instance.
+        /// <para>Calculates the hash code for the current <see cref="Range{T}"/> instance.</para>
+        /// <para>Вычисляет хэш-код для текущего экземпляра <see cref="Range{T}"/>.</para>
         /// </summary>
-        /// <returns>The hash code for the current <see cref="Range{T}"/> instance.</returns>
+        /// <returns><para>The hash code for the current <see cref="Range{T}"/> instance.</para><para>Хэш-код для текущего экземпляра <see cref="Range{T}"/>.</para></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override int GetHashCode() => (Minimum, Maximum).GetHashCode();
 


### PR DESCRIPTION
## Summary
- Added missing `<typeparam>` description for generic type `T` in `Range<T>` struct  
- Added bilingual return type description for `GetHashCode` method
- Completed parameter descriptions for `argument` parameters in `EnsureExtensions.cs`

## Test plan
- [x] Built solution successfully with `dotnet build`
- [x] All tests pass with `dotnet test`
- [x] Documentation builds without warnings
- [x] No breaking changes to public API

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #29