### PR TITLE
Complete internationalization of code comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Ranges/issues/13
+Your prepared branch: issue-13-5fadd610
+Your prepared working directory: /tmp/gh-issue-solver-1757842056436
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Ranges/issues/13
-Your prepared branch: issue-13-5fadd610
-Your prepared working directory: /tmp/gh-issue-solver-1757842056436
-
-Proceed.

--- a/csharp/Platform.Ranges/EnsureExtensions.cs
+++ b/csharp/Platform.Ranges/EnsureExtensions.cs
@@ -225,7 +225,7 @@ namespace Platform.Ranges
         /// </summary>
         /// <typeparam name="TArgument"><para>Type of argument.</para><para>Тип аргумента.</para></typeparam>
         /// <param name="root"><para>The extension root to which this method is bound.</para><para>Корень-расширения, к которому привязан этот метод.</para></param>
-        /// <param name="argument"></param>
+        /// <param name="argument"><para>The argument's value.</para><para>Значение аргумента.</para></param>
         /// <param name="range"><para>The range restriction.</para><para>Ограничение в виде диапазона.</para></param>
         /// <param name="argumentName"><para>The argument's name.</para><para>Имя аргумента.</para></param>
         /// <param name="messageBuilder"><para>The thrown exception's message building <see cref="Func{String}"/>.</para><para>Собирающая сообщение для выбрасываемого исключения <see cref="Func{String}"/>.</para></param>
@@ -238,7 +238,7 @@ namespace Platform.Ranges
         /// </summary>
         /// <typeparam name="TArgument"><para>Type of argument.</para><para>Тип аргумента.</para></typeparam>
         /// <param name="root"><para>The extension root to which this method is bound.</para><para>Корень-расширения, к которому привязан этот метод.</para></param>
-        /// <param name="argument"></param>
+        /// <param name="argument"><para>The argument's value.</para><para>Значение аргумента.</para></param>
         /// <param name="range"><para>The range restriction.</para><para>Ограничение в виде диапазона.</para></param>
         /// <param name="argumentName"><para>The argument's name.</para><para>Имя аргумента.</para></param>
         /// <param name="message"><para>The message of the thrown exception.</para><para>Сообщение выбрасываемого исключения.</para></param>
@@ -251,7 +251,7 @@ namespace Platform.Ranges
         /// </summary>
         /// <typeparam name="TArgument"><para>Type of argument.</para><para>Тип аргумента.</para></typeparam>
         /// <param name="root"><para>The extension root to which this method is bound.</para><para>Корень-расширения, к которому привязан этот метод.</para></param>
-        /// <param name="argument"></param>
+        /// <param name="argument"><para>The argument's value.</para><para>Значение аргумента.</para></param>
         /// <param name="range"><para>The range restriction.</para><para>Ограничение в виде диапазона.</para></param>
         /// <param name="argumentName"><para>The argument's name.</para><para>Имя аргумента.</para></param>
         [Conditional("DEBUG")]
@@ -288,7 +288,7 @@ namespace Platform.Ranges
         /// </summary>
         /// <typeparam name="TArgument"><para>Type of argument.</para><para>Тип аргумента.</para></typeparam>
         /// <param name="root"><para>The extension root to which this method is bound.</para><para>Корень-расширения, к которому привязан этот метод.</para></param>
-        /// <param name="argument"></param>
+        /// <param name="argument"><para>The argument's value.</para><para>Значение аргумента.</para></param>
         /// <param name="range"><para>The range restriction.</para><para>Ограничение в виде диапазона.</para></param>
         [Conditional("DEBUG")]
         public static void ArgumentInRange<TArgument>(this EnsureOnDebugExtensionRoot root, TArgument argument, Range<TArgument> range) => Ensure.Always.ArgumentInRange(argument, range, null);

--- a/csharp/Platform.Ranges/Range[T].cs
+++ b/csharp/Platform.Ranges/Range[T].cs
@@ -118,9 +118,10 @@ namespace Platform.Ranges
         public override bool Equals(object obj) => obj is Range<T> range ? Equals(range) : false;
 
         /// <summary>
-        /// Calculates the hash code for the current <see cref="Range{T}"/> instance.
+        /// <para>Calculates the hash code for the current <see cref="Range{T}"/> instance.</para>
+        /// <para>Вычисляет хэш-код для текущего экземпляра <see cref="Range{T}"/>.</para>
         /// </summary>
-        /// <returns>The hash code for the current <see cref="Range{T}"/> instance.</returns>
+        /// <returns><para>The hash code for the current <see cref="Range{T}"/> instance.</para><para>Хэш-код для текущего экземпляра <see cref="Range{T}"/>.</para></returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public override int GetHashCode() => (Minimum, Maximum).GetHashCode();
 


### PR DESCRIPTION
## Summary

This PR completes the internationalization of code comments by fixing missing Russian translations in XML documentation comments.

### Changes Made

- **Range[T].cs**: Added missing Russian translation to `GetHashCode()` method XML documentation
- **EnsureExtensions.cs**: Completed missing Russian translations for parameter documentation in 4 method overloads

### Details

All XML documentation comments now follow the consistent bilingual format:
```xml
/// <param name="argument"><para>The argument's value.</para><para>Значение аргумента.</para></param>
```

The codebase already had extensive internationalization with English and Russian translations, but a few documentation elements were incomplete. This PR ensures complete consistency across all XML documentation comments.

### Testing

- All existing C# tests pass ✅
- Project builds successfully with no errors ✅
- Documentation generation will now be complete for both languages

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #13